### PR TITLE
Add gas-report tracking on repository

### DIFF
--- a/.gas-report
+++ b/.gas-report
@@ -1,0 +1,35 @@
+| contracts/MiniMeToken.sol:MiniMeToken contract |                 |         |         |         |         |
+|------------------------------------------------|-----------------|---------|---------|---------|---------|
+| Deployment Cost                                | Deployment Size |         |         |         |         |
+| 1788057                                        | 9919            |         |         |         |         |
+| Function Name                                  | min             | avg     | median  | max     | # calls |
+| allowance                                      | 808             | 808     | 808     | 808     | 2       |
+| approve                                        | 31708           | 31708   | 31708   | 31708   | 1       |
+| balanceOf                                      | 2361            | 3441    | 2361    | 5601    | 9       |
+| balanceOfAt                                    | 1142            | 2585    | 2363    | 3603    | 26      |
+| changeController                               | 758             | 758     | 758     | 758     | 4       |
+| controller                                     | 2447            | 2447    | 2447    | 2447    | 6       |
+| createCloneToken                               | 1832796         | 1832796 | 1832796 | 1832796 | 2       |
+| decimals                                       | 294             | 294     | 294     | 294     | 6       |
+| destroyTokens                                  | 8956            | 8956    | 8956    | 8956    | 1       |
+| generateTokens                                 | 2541            | 80795   | 94453   | 95751   | 10      |
+| name                                           | 3253            | 3253    | 3253    | 3253    | 6       |
+| parentSnapShotBlock                            | 284             | 284     | 284     | 284     | 7       |
+| parentToken                                    | 305             | 305     | 305     | 305     | 7       |
+| symbol                                         | 3274            | 3274    | 3274    | 3274    | 6       |
+| totalSupply                                    | 1911            | 2917    | 1911    | 4930    | 6       |
+| totalSupplyAt                                  | 1995            | 3029    | 3003    | 4606    | 7       |
+| transfer                                       | 75187           | 75187   | 75187   | 75187   | 1       |
+| transferFrom                                   | 74194           | 74194   | 74194   | 74194   | 1       |
+
+
+| contracts/MiniMeTokenFactory.sol:MiniMeTokenFactory contract |                 |         |         |         |         |
+|--------------------------------------------------------------|-----------------|---------|---------|---------|---------|
+| Deployment Cost                                              | Deployment Size |         |         |         |         |
+| 2111243                                                      | 10577           |         |         |         |         |
+| Function Name                                                | min             | avg     | median  | max     | # calls |
+| createCloneToken                                             | 1825218         | 1825218 | 1825218 | 1825218 | 2       |
+
+
+
+ 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@ Ensure you completed **all of the steps** below before submitting your pull requ
 - [ ] Added natspec comments?
 - [ ] Ran `forge snapshot`?
 - [ ] Ran `pnpm lint`?
-- [ ] Ran `forge test`?
+- [ ] Ran `pnpm gas-report`?

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@
   cbor_metadata = false
   evm_version = "paris"
   fuzz = { runs = 1_000 }
-  gas_reports = ["*"]
+  gas_reports = ["MiniMeToken", "MiniMeTokenFactory"]
   libs = ["lib"]
   optimizer = true
   optimizer_runs = 10_000

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "private": true,
   "scripts": {
+    "gas-report": "forge test --gas-report | awk '/Test result:/ {found=1; buffer=\"\"; next} found && !/Ran/ {buffer=buffer $0 ORS} /Ran/ {found=0} END {printf \"%s\", buffer}' > .gas-report",
     "clean": "rm -rf cache out",
     "lint": "pnpm lint:sol && pnpm prettier:check",
     "lint:sol": "forge fmt --check && pnpm solhint {script,src,test}/**/*.sol",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "private": true,
   "scripts": {
-    "gas-report": "forge test --gas-report | awk '/Test result:/ {found=1; buffer=\"\"; next} found && !/Ran/ {buffer=buffer $0 ORS} /Ran/ {found=0} END {printf \"%s\", buffer}' > .gas-report",
+    "gas-report": "forge test --gas-report 2>&1 | (tee /dev/tty | awk '/Test result:/ {found=1; buffer=\"\"; next} found && !/Ran/ {buffer=buffer $0 ORS} /Ran/ {found=0} END {printf \"%s\", buffer}' > .gas-report)",
     "clean": "rm -rf cache out",
     "lint": "pnpm lint:sol && pnpm prettier:check",
     "lint:sol": "forge fmt --check && pnpm solhint {script,src,test}/**/*.sol",


### PR DESCRIPTION
Fixes vacp2p/minime#21

## Description

- Add `npm run gas-report` to save the reports of gas usage of each function in the smart contracts of interest.

- sets foundry.toml to gas_reports = ["MiniMeToken", "MiniMeTokenFactory"]

- add first .gas-report

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [x] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
